### PR TITLE
Check challenge before presenting it

### DIFF
--- a/pkg/issuer/acme/acme.go
+++ b/pkg/issuer/acme/acme.go
@@ -71,6 +71,10 @@ type solver interface {
 	// needs to create any new resources, it can set the appropriate owner
 	// reference
 	Present(ctx context.Context, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error
+
+	// Check should return Error only if propagation check cannot be performed.
+	// It MUST return `false, nil` if can contact all relevant services and all is
+	// doing is waiting for propagation
 	Check(ch v1alpha1.ACMEOrderChallenge) (bool, error)
 	CleanUp(ctx context.Context, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error
 }

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -86,7 +86,8 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 			return false, err
 		}
 
-		if r.Rcode != dns.RcodeSuccess {
+		// NXDomain response is not really an error, just waiting for propagation to happen
+		if !(r.Rcode == dns.RcodeSuccess || r.Rcode == dns.RcodeNameError) {
 			return false, fmt.Errorf("NS %s returned %s for %s", ns, dns.RcodeToString[r.Rcode], fqdn)
 		}
 
@@ -102,7 +103,7 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 		}
 
 		if !found {
-			return false, fmt.Errorf("nameserver %q did not return the expected TXT record for domain %q", ns, fqdn)
+			return false, nil
 		}
 	}
 


### PR DESCRIPTION
With async challenge Check, it is often happens,
that solver.Check() fails on first run after solver.Present()

Cert-manager then tries again, but starts with solver.Present(),
which not being idempotent right now fails on certain DNS providers.

This change swaps order of solver.Check() and solver.Present().
Check is not returning error if propagation not happened, it then
allows Present() to run.

In the current form, Present() will be spamming with errors,
but this doesn't stop Check from happening on every attempt,
so eventually Challenge can be verified and accepted. In the future,
Present() should be made idempotent.


