### PR TITLE
Added annotation to pod to prevent istio-sidecar-injector to add an envoy-proxy

### DIFF
--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -113,6 +113,9 @@ func (s *Solver) buildPod(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChalle
 			GenerateName:    "cm-acme-http-solver-",
 			Namespace:       crt.Namespace,
 			Labels:          podLabels,
+			Annotations: map[string]string{
+				"sidecar.istio.io/inject": "false",
+			},
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
Implemented the suggestion spoken previously at https://github.com/jetstack/cert-manager/pull/622#issuecomment-395493887